### PR TITLE
todo passed and output file and line

### DIFF
--- a/lib/Test/Clear.pm
+++ b/lib/Test/Clear.pm
@@ -56,9 +56,13 @@ sub todo_scope {
 sub todo_note {
     my ($caption, $reason) = @_;
     $reason ||= '';
+
+    my (undef, $file, $line) = caller(0);
+    $reason .= " [ $file line $line ]\n";
+
     my $tb = Test::More->builder;
     $tb->todo_start($reason);
-    fail $caption;
+    pass $caption;
     $tb->todo_end;
 }
 


### PR DESCRIPTION
- failではなくpassにして、todo passに表示させるように(不要なfailメッセージの除去)
- コメントにfileとlineを表示するように
